### PR TITLE
GLUE-262 Feat : 게이트웨이 인가 필터 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,15 @@ dependencies {
 
 	// netty - macOS set
 	implementation 'io.netty:netty-resolver-dns-native-macos:4.1.68.Final:osx-aarch_64'
+
+	// lombok
+	compileOnly 'org.projectlombok:lombok'
+	annotationProcessor 'org.projectlombok:lombok'
+
+	// jwt
+	implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.12.5'
+	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.12.5'
+	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.12.5'
 }
 
 dependencyManagement {

--- a/src/main/java/com/justdo/glue/gateway/filter/AuthorizationHeaderFilter.java
+++ b/src/main/java/com/justdo/glue/gateway/filter/AuthorizationHeaderFilter.java
@@ -1,0 +1,65 @@
+package com.justdo.glue.gateway.filter;
+
+import com.justdo.glue.gateway.utils.JwtTokenProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.factory.AbstractGatewayFilterFactory;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.http.server.reactive.ServerHttpResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+import java.util.Objects;
+
+@Component
+public class AuthorizationHeaderFilter extends AbstractGatewayFilterFactory<AuthorizationHeaderFilter.Config> {
+
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
+    public AuthorizationHeaderFilter() {
+        super(Config.class);
+    }
+
+    public static class Config {
+
+    }
+
+    @Override
+    public GatewayFilter apply(Config config) {
+        return ((exchange, chain) -> {
+            ServerHttpRequest request = exchange.getRequest();
+
+            String requestUrl = exchange.getRequest().getPath().toString();
+
+            if (requestUrl.startsWith("/auths/v3/api-docs") ||
+                    requestUrl.startsWith("/blogs/v3/api-docs") ||
+                    requestUrl.startsWith("/posts/v3/api-docs")) {
+                return chain.filter(exchange);
+            }
+
+            if (!request.getHeaders().containsKey(HttpHeaders.AUTHORIZATION)) {
+                return onError(exchange, "no authorization header");
+            }
+
+            String authorizationHeader = Objects.requireNonNull(request.getHeaders().get(HttpHeaders.AUTHORIZATION)).get(0);
+            String jwt = authorizationHeader.replace("Bearer", "").trim();
+
+            if (!jwtTokenProvider.isTokenValid(jwt)) {
+                return onError(exchange, "JWT Token is not valid");
+            }
+
+            return chain.filter(exchange);
+        });
+    }
+
+    private Mono<Void> onError(ServerWebExchange exchange, String err) {
+        ServerHttpResponse response = exchange.getResponse();
+        response.setStatusCode(HttpStatus.UNAUTHORIZED);
+
+        return response.setComplete();
+    }
+}

--- a/src/main/java/com/justdo/glue/gateway/utils/JwtTokenProvider.java
+++ b/src/main/java/com/justdo/glue/gateway/utils/JwtTokenProvider.java
@@ -1,0 +1,38 @@
+package com.justdo.glue.gateway.utils;
+
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.util.Base64;
+import java.util.Date;
+
+@Component
+@RequiredArgsConstructor
+public class JwtTokenProvider {
+
+    @Value("${jwt.secret}")
+    private String secretKey;
+
+    private SecretKey getSecretKey() {
+        String keyBase64Encoded = Base64.getEncoder().encodeToString(secretKey.getBytes());
+        return Keys.hmacShaKeyFor(keyBase64Encoded.getBytes());
+    }
+
+    public boolean isTokenValid(String token) {
+        try {
+            SecretKey secretKey = getSecretKey();
+
+            Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token);
+            return true;
+        } catch (JwtException e) {
+            // 유효하지 않은 토큰이므로 false 반환
+            return false;
+        }
+    }
+
+}


### PR DESCRIPTION
## 📌 요약

- 게이트웨이 서버의 통합 인가 필터를 구현하였습니다.

## 📝 상세 내용

- auth, blog, post server들의 swagger url은 제외하고, jwt access token 인증 필터를 거쳐 개별 서비스로 라우팅 됩니다.
- 현재 로직만 구현되어 있는 상태이며 예외 핸들링을 추가해야합니다.

## 🗣️ 질문 및 이외 사항

-

## ☑️ 이슈 번호

- close #
