### PR TITLE
GLUE-100 Refactor : 로그인 api 필터 제외

### DIFF
--- a/src/main/java/com/justdo/glue/gateway/filter/AuthorizationHeaderFilter.java
+++ b/src/main/java/com/justdo/glue/gateway/filter/AuthorizationHeaderFilter.java
@@ -37,7 +37,8 @@ public class AuthorizationHeaderFilter extends AbstractGatewayFilterFactory<Auth
 
             if (requestUrl.startsWith("/auths/v3/api-docs") ||
                     requestUrl.startsWith("/blogs/v3/api-docs") ||
-                    requestUrl.startsWith("/posts/v3/api-docs")) {
+                    requestUrl.startsWith("/posts/v3/api-docs") ||
+                    requestUrl.startsWith("/auths/login")){
                 return chain.filter(exchange);
             }
 

--- a/src/main/java/com/justdo/glue/gateway/filter/AuthorizationHeaderFilter.java
+++ b/src/main/java/com/justdo/glue/gateway/filter/AuthorizationHeaderFilter.java
@@ -38,6 +38,7 @@ public class AuthorizationHeaderFilter extends AbstractGatewayFilterFactory<Auth
             if (requestUrl.startsWith("/auths/v3/api-docs") ||
                     requestUrl.startsWith("/blogs/v3/api-docs") ||
                     requestUrl.startsWith("/posts/v3/api-docs") ||
+                    requestUrl.startsWith("/recommends/openapi.json") ||
                     requestUrl.startsWith("/auths/login")){
                 return chain.filter(exchange);
             }


### PR DESCRIPTION
## 📌 요약

- 추가된 카카오 로그인 api가 게이트웨이 인가 필터 로직에서 제외되도록 수정

## 📝 상세 내용

- 요약과 동일

## 🗣️ 질문 및 이외 사항

-

## ☑️ 이슈 번호

- close #
